### PR TITLE
Fix image rendering in chat messages

### DIFF
--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -65,7 +65,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
         const reader = new FileReader();
         reader.onload = () => {
           const imageUrl = reader.result as string;
-          onSendMessage(`[Bild: ${file.name}](${imageUrl})`);
+          onSendMessage(`![${file.name}](${imageUrl})`);
         };
         reader.readAsDataURL(file);
       }

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -157,11 +157,19 @@ const MessageList: React.FC<MessageListProps> = ({ messages, className }) => {
                       
                       <div className={cn(
                         "px-4 py-2 rounded-lg",
-                        message.isMe 
-                          ? "bg-primary text-primary-foreground rounded-tr-none" 
+                        message.isMe
+                          ? "bg-primary text-primary-foreground rounded-tr-none"
                           : "bg-muted rounded-tl-none"
                       )}>
-                        <p className="text-sm whitespace-pre-line">{message.text}</p>
+                        {/^!\[.*\]\((data:image\/[^)]+)\)$/.test(message.text) ? (
+                          <img
+                            src={message.text.match(/^!\[.*\]\((data:image\/[^)]+)\)$/)![1]}
+                            alt="uploaded"
+                            className="max-w-xs rounded"
+                          />
+                        ) : (
+                          <p className="text-sm whitespace-pre-line">{message.text}</p>
+                        )}
                       </div>
                       
                       <span className="text-xs text-muted-foreground mt-1">

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -31,7 +31,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/components/ui/use-toast";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger, DialogClose } from "@/components/ui/dialog";
 import { supabase } from '@/integrations/supabase/client';
 import { Profile, ExtendedProfile } from '@/types/supabase';
 import { useNavigate } from 'react-router-dom';
@@ -996,7 +996,9 @@ const Settings = () => {
                                   </ul>
                                 </div>
                                 <DialogFooter>
-                                  <Button type="button">Jag förstår</Button>
+                                  <DialogClose asChild>
+                                    <Button type="button">Jag förstår</Button>
+                                  </DialogClose>
                                 </DialogFooter>
                               </DialogContent>
                             </Dialog>
@@ -1035,17 +1037,21 @@ const Settings = () => {
                                   </ul>
                                 </div>
                                 <DialogFooter className="flex gap-2 sm:justify-between">
-                                  <Button type="button" variant="outline" className="sm:flex-grow">
-                                    Avbryt
-                                  </Button>
-                                  <Button 
-                                    type="button" 
-                                    variant="destructive" 
-                                    className="sm:flex-grow"
-                                    onClick={confirmDataDeletion}
-                                  >
-                                    Bekräfta radering
-                                  </Button>
+                                  <DialogClose asChild>
+                                    <Button type="button" variant="outline" className="sm:flex-grow">
+                                      Avbryt
+                                    </Button>
+                                  </DialogClose>
+                                  <DialogClose asChild>
+                                    <Button
+                                      type="button"
+                                      variant="destructive"
+                                      className="sm:flex-grow"
+                                      onClick={confirmDataDeletion}
+                                    >
+                                      Bekräfta radering
+                                    </Button>
+                                  </DialogClose>
                                 </DialogFooter>
                               </DialogContent>
                             </Dialog>


### PR DESCRIPTION
## Summary
- allow MessageInput to generate markdown image syntax
- detect markdown image links in MessageList and render `<img>`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*