### PR TITLE
Fix dialogs and allow file download

### DIFF
--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -97,7 +97,8 @@ const MessageInput: React.FC<MessageInputProps> = ({
       onSendFile(file);
     } else {
       // Fallback if no handler provided
-      onSendMessage(`[Dokument: ${file.name}]`);
+      const fileUrl = URL.createObjectURL(file);
+      onSendMessage(`[Dokument: ${file.name}](${fileUrl})`);
     }
     
     toast({

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef } from 'react';
 import { cn } from "@/lib/utils";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Download } from 'lucide-react';
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { format, parseISO } from 'date-fns';
 import { sv } from 'date-fns/locale';
@@ -161,7 +162,23 @@ const MessageList: React.FC<MessageListProps> = ({ messages, className }) => {
                           ? "bg-primary text-primary-foreground rounded-tr-none" 
                           : "bg-muted rounded-tl-none"
                       )}>
-                        <p className="text-sm whitespace-pre-line">{message.text}</p>
+                        {(() => {
+                          const imgMatch = message.text.match(/^\[Bild: ([^\]]+)\]\((.+)\)$/);
+                          if (imgMatch) {
+                            const [, alt, url] = imgMatch;
+                            return <img src={url} alt={alt} className="max-w-xs rounded-lg" />;
+                          }
+                          const docMatch = message.text.match(/^\[Dokument: ([^\]]+)\]\((.+)\)$/);
+                          if (docMatch) {
+                            const [, name, url] = docMatch;
+                            return (
+                              <a href={url} download className="text-primary underline flex items-center gap-1">
+                                <Download className="w-4 h-4" /> {name}
+                              </a>
+                            );
+                          }
+                          return <p className="text-sm whitespace-pre-line">{message.text}</p>;
+                        })()}
                       </div>
                       
                       <span className="text-xs text-muted-foreground mt-1">

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -31,7 +31,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/components/ui/use-toast";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger, DialogClose } from "@/components/ui/dialog";
 import { supabase } from '@/integrations/supabase/client';
 import { Profile, ExtendedProfile } from '@/types/supabase';
 import { useNavigate } from 'react-router-dom';
@@ -996,7 +996,9 @@ const Settings = () => {
                                   </ul>
                                 </div>
                                 <DialogFooter>
-                                  <Button type="button">Jag förstår</Button>
+                                  <DialogClose asChild>
+                                    <Button type="button">Jag förstår</Button>
+                                  </DialogClose>
                                 </DialogFooter>
                               </DialogContent>
                             </Dialog>
@@ -1035,17 +1037,21 @@ const Settings = () => {
                                   </ul>
                                 </div>
                                 <DialogFooter className="flex gap-2 sm:justify-between">
-                                  <Button type="button" variant="outline" className="sm:flex-grow">
-                                    Avbryt
-                                  </Button>
-                                  <Button 
-                                    type="button" 
-                                    variant="destructive" 
-                                    className="sm:flex-grow"
-                                    onClick={confirmDataDeletion}
-                                  >
-                                    Bekräfta radering
-                                  </Button>
+                                  <DialogClose asChild>
+                                    <Button type="button" variant="outline" className="sm:flex-grow">
+                                      Avbryt
+                                    </Button>
+                                  </DialogClose>
+                                  <DialogClose asChild>
+                                    <Button
+                                      type="button"
+                                      variant="destructive"
+                                      className="sm:flex-grow"
+                                      onClick={confirmDataDeletion}
+                                    >
+                                      Bekräfta radering
+                                    </Button>
+                                  </DialogClose>
                                 </DialogFooter>
                               </DialogContent>
                             </Dialog>


### PR DESCRIPTION
## Summary
- create object URL for fallback file upload messages
- render uploaded images or documents in chat
- enable closing dialogs via action buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*