### PR TITLE
Fix toast listener duplication

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -181,7 +181,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure useToast registers the listener only once

## Testing
- `npm install` *(fails: EHOSTUNREACH)*
- `bun install` *(fails: ConnectionRefused)*