### PR TITLE
feat: add RPC for fetching last direct messages

### DIFF
--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -2,7 +2,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useToast } from '@/components/ui/use-toast';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase, getUsersWithLastMessage } from '@/integrations/supabase/client';
 import { formatDate } from '@/utils/dateUtils';
 import { UserWithLastMessage } from '@/components/messages/MessageListItem';
 
@@ -32,50 +32,20 @@ export const useMessages = () => {
         }
         
         const currentUserId = session.user.id;
-        
-        // Hämta alla användare
-        const { data: profiles, error } = await supabase
-          .from('profiles')
-          .select('*')
-          .neq('id', currentUserId);  // Filtrera bort den aktuella användaren
-          
+
+        const { data, error } = await getUsersWithLastMessage(currentUserId);
+
         if (error) {
           throw error;
         }
-        
-        if (profiles) {
-          const formattedUsers: UserWithLastMessage[] = await Promise.all(profiles.map(async (profile) => {
-            // Hämta senaste meddelandet mellan aktuell användare och denna användare
-            // Den tidigare implementationen hämtade meddelanden där någon av
-            // användarna deltog, vilket kunde ge fel resultat om det fanns
-            // meddelanden med andra användare. Här ser vi till att endast
-            // meddelanden mellan de två specifika användarna hämtas.
-            const {
-              data: messages,
-              error: lastMsgError
-            } = await supabase
-              .from('direct_messages')
-              .select('*')
-              .or(
-                `and(sender_id.eq.${currentUserId},recipient_id.eq.${profile.id}),` +
-                `and(sender_id.eq.${profile.id},recipient_id.eq.${currentUserId})`
-              )
-              .order('created_at', { ascending: false })
-              .limit(1);
 
-            const lastMsg = messages && messages[0];
-              
-            let lastMessage: { text: string; timestamp: Date } | undefined;
+        if (data) {
+          const formattedUsers: UserWithLastMessage[] = data.map(profile => {
+            const lastMessage = profile.content && profile.created_at ? {
+              text: profile.content,
+              timestamp: new Date(profile.created_at)
+            } : undefined;
 
-            if (lastMsgError) {
-              console.error('Error fetching last message:', lastMsgError);
-            } else if (lastMsg) {
-              lastMessage = {
-                text: lastMsg.content,
-                timestamp: new Date(lastMsg.created_at)
-              };
-            }
-            
             return {
               id: profile.id,
               name: profile.name || 'Okänd användare',
@@ -86,8 +56,8 @@ export const useMessages = () => {
               apartment: profile.apartment || undefined,
               lastMessage
             };
-          }));
-          
+          });
+
           setUsers(formattedUsers);
         }
       } catch (error: any) {

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -17,5 +17,8 @@ export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABL
   }
 });
 
+export const getUsersWithLastMessage = (currentUserId: string) =>
+  supabase.rpc('get_users_with_last_message', { current_user_id: currentUserId });
+
 // Export types from the types file
 export type { Database } from './types';

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -195,7 +195,22 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      get_users_with_last_message: {
+        Args: {
+          current_user_id: string
+        }
+        Returns: {
+          id: string
+          name: string | null
+          is_online: boolean | null
+          last_seen: string | null
+          is_admin: boolean | null
+          avatar: string | null
+          apartment: string | null
+          content: string | null
+          created_at: string | null
+        }[]
+      }
     }
     Enums: {
       [_ in never]: never

--- a/supabase/functions/get_users_with_last_message.sql
+++ b/supabase/functions/get_users_with_last_message.sql
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION public.get_users_with_last_message(current_user_id uuid)
+RETURNS TABLE (
+  id uuid,
+  name text,
+  is_online boolean,
+  last_seen timestamptz,
+  is_admin boolean,
+  avatar text,
+  apartment text,
+  content text,
+  created_at timestamptz
+)
+LANGUAGE sql STABLE AS $$
+  select p.id,
+         p.name,
+         p.is_online,
+         p.last_seen,
+         p.is_admin,
+         p.avatar,
+         p.apartment,
+         dm.content,
+         dm.created_at
+  from profiles p
+  left join lateral (
+    select content, created_at
+    from direct_messages
+    where (sender_id = current_user_id and recipient_id = p.id)
+       or (sender_id = p.id and recipient_id = current_user_id)
+    order by created_at desc
+    limit 1
+  ) dm on true
+  where p.id <> current_user_id;
+$$;


### PR DESCRIPTION
## Summary
- add SQL function `get_users_with_last_message` to fetch latest direct messages per user
- expose helper `getUsersWithLastMessage` on Supabase client
- refactor `useMessages` to use the RPC instead of multiple queries

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Unexpected any, forbidden require, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68a460a24d34832ebb0fc8cd480b6068